### PR TITLE
Refactor 1.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+# CI/CD workflow for siebenuhr_core
+# Runs native unit tests on push and pull requests
+
+name: Tests
+
+on:
+  push:  # Run on any branch push
+  pull_request:
+    branches: [main, master, develop]
+  workflow_dispatch:  # Allow manual trigger from GitHub UI
+
+jobs:
+  native-tests:
+    name: Native Unit Tests
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+          restore-keys: |
+            pio-${{ runner.os }}-
+      
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install platformio
+      
+      - name: Run native tests
+        run: pio test -e native -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.1.0 (Jan 2026)
 
 - Brightness scaling: non-linear steps for finer control at low brightness, minimum reduced from 5 to 1
-- Double-click on buttons now cycles through display personalities
+- Double-click personality cycling via `DOUBLE_CLICK_PERSONALITY_ENABLED` build flag (off by default)
 - Sensor reading interval configurable via `SENSOR_READ_INTERVAL_MS` build flag (default 10s)
 - Encoder feedback LED now optional via constructor parameter
 - Added test suites runnable in native (non-hw) environment using mocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## v1.1.0 (Jan 2026)
+
+- Brightness scaling: non-linear steps for finer control at low brightness, minimum reduced from 5 to 1
+- Double-click on buttons now cycles through display personalities
+- Sensor reading interval configurable via `SENSOR_READ_INTERVAL_MS` build flag (default 10s)
+- Encoder feedback LED now optional via constructor parameter
+- Added test suites runnable in native (non-hw) environment using mocks
+- Added platformio.ini for running tests
+- Added CI workflow for automated testing
+- Documented build flags and runtime configuration APIs
+- Added `FASTLED_DITHER_ENABLED` build flag (disabled by default to prevent flicker at low brightness)
+- Fixed LED pin mapping: heartbeat now on GPIO 5, button LEDs on correct pins
+- Heartbeat LED dims to ~10% brightness, toggles every 1s
+- Button LEDs light when pressed
+- FPS stats logged at verbose level only
+- Removed deprecated `readAndPrintPowerMonitoring()` method
+- Fixed logger switch statement missing NONE case
+
+## v1.0.0 (2025)
+
+- initial release supporting Miniclock and Controller boards, for both ESPHome and PlatformIO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,39 @@
 - Removed deprecated `readAndPrintPowerMonitoring()` method
 - Fixed logger switch statement missing NONE case
 
-## v1.0.0 (2025)
+## v1.0.10 (Apr - Dec 2025)
 
-- initial release supporting Miniclock and Controller boards, for both ESPHome and PlatformIO
+Feature-complete release with all personalities and controls.
+
+- Added Rainbow, Mosaik, Glitter personalities (Apr-May)
+- Button class with single-click, double-click, long-press support (May)
+- Notification system with overlay rendering (May)
+- Refactored controller and logger (May)
+- High-precision hue manipulation for color accuracy (May)
+- Device reset event detection (May)
+- Accesspoint and render state management (Jun)
+
+## v1.0.5 - v1.0.7 (Apr 2025)
+
+Rapid iteration adding core functionality.
+
+- v1.0.7: Rotary encoder prewiring
+- v1.0.6: Sensor settings (BH1750, INA219)
+- v1.0.5: ColorWheel personality
+
+## v1.0.1 - v1.0.4 (Apr 2025)
+
+Initial versioned releases.
+
+- v1.0.4: ESPHome integration, color/brightness/power control
+- v1.0.1: Auto-brightness support, first version macro
+
+## v1.0.0 (Dec 2024 - Apr 2025)
+
+Initial development and library structure.
+
+- Library scaffolding for PlatformIO and ESPHome
+- Display and Glyph classes
+- ASCII character rendering
+- SolidColor personality
+- Snake test effect

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Dependent projects:
 
 | Function | GPIO | Notes |
 |----------|------|-------|
-| LED 1 (RGB Strip) | 21 | FastLED addressable LEDs (WS2812/SK6812) |
-| LED 2 | 22 | PWM (unused) |
-| LED 3 | 19 | PWM, near Boot Button |
-| LED 4 | 23 | PWM, near User Button |
+| DOUT (RGB Strip) | 21 | FastLED addressable LEDs (WS2812/SK6812) |
+| LED 1 | 22 | PWM  near BH1750, for future calibration use|
+| LED 2 | 19 | PWM, near Boot Button |
+| LED 3 | 23 | PWM, near User Button |
 | Heartbeat LED | 5 | PWM, orange, blinks every 1s |
 | User Button | 33 | |
 | Boot Button | 0 | |
@@ -126,14 +126,16 @@ The core library uses these compile-time flags (set in `platformio.ini`):
 
 ```ini
 build_flags = 
-    -D SENSOR_READ_INTERVAL_MS=10000  ; Sensor polling interval in ms (default: 10000)
-    -D FASTLED_DITHER_ENABLED=1       ; Enable FastLED temporal dithering (off by default)
+    -D SENSOR_READ_INTERVAL_MS=10000    ; Sensor polling interval in ms (default: 10000)
+    -D FASTLED_DITHER_ENABLED=1         ; Enable FastLED temporal dithering (off by default)
+    -D DOUBLE_CLICK_PERSONALITY_ENABLED ; Enable double-click to cycle personalities
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `SENSOR_READ_INTERVAL_MS` | 10000 | How often to read I2C sensors (BH1750, INA219) |
 | `FASTLED_DITHER_ENABLED` | off | Enable temporal dithering (can cause flicker at low brightness) |
+| `DOUBLE_CLICK_PERSONALITY_ENABLED` | off | Double-click buttons to cycle display personalities |
 
 ### Runtime Configuration
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The `siebenuhr_core` library is the heart of the Siebenuhr LED clock. It provides reusable and maintainable components for driving the clock's functionality. This library is designed to support integration with Home Assistant via ESPHome as well as standalone firmware for users without a Home Assistant setup.
 
+Dependent projects:
+- https://github.com/soliddifference/siebenuhr_esphome
+- https://github.com/soliddifference/siebenuhr
+
 ## Features
 
 - **LED Topology Management**: Define and manage the layout of LEDs to display glyphs and animations.
@@ -9,23 +13,47 @@ The `siebenuhr_core` library is the heart of the Siebenuhr LED clock. It provide
 - **Glyph Rendering**: Handle the display of predefined or custom glyphs on the clock face.
 - **Text Handling**: Render and manage text output for the clock display.
 
+## Hardware 
+
+*(both Miniclock and Controller boards)*
+
+| Function | GPIO | Notes |
+|----------|------|-------|
+| LED 1 (RGB Strip) | 21 | FastLED addressable LEDs (WS2812/SK6812) |
+| LED 2 | 22 | PWM (unused) |
+| LED 3 | 19 | PWM, near Boot Button |
+| LED 4 | 23 | PWM, near User Button |
+| Heartbeat LED | 5 | PWM, orange, blinks every 1s |
+| User Button | 33 | |
+| Boot Button | 0 | |
+| Rotary Encoder | 26, 27, 18 | A, B, Button |
+
+*I2C sensors:*
+
+- BH1750 (0x23) - Ambient light sensor
+- INA219 (0x40) - Power monitoring
+
 ## Getting Started
 
-This repository is a work in progress. Additional documentation and usage examples will be added as the project evolves.
+### Requirements
+
+- **Platform**: ESP32 (ESP32-MINI-1-N4, 4MB flash, no PSRAM)
+- **Framework**: Arduino (PlatformIO compatibility)
+- **Development**: Python 3.8+ with PlatformIO
 
 ### Repository Structure
 
 ```
 siebenuhr_core/
-├── include/          # Public header files
-├── src/              # Core source files
-└── library.json      # PlatformIO library metadata
+├── src/              # Core library source files
+│   ├── Personalities/    # Display renderers (ColorWheel, Rainbow, etc.)
+│   └── FX/               # Special effects
+├── test/             # Native unit tests
+│   ├── mocks/            # Arduino/FastLED mocks for desktop testing
+│   └── test_*/           # Test suites
+├── library.json      # PlatformIO library metadata
+└── platformio.ini    # Test configuration (not used by dependents)
 ```
-
-### Requirements
-
-- **Platform**: ESP32
-- **Framework**: Arduino (PlatformIO compatibility)
 
 ## Usage
 
@@ -65,6 +93,60 @@ libraries:
 
 Replace the path above with the location of your locally checked-out repository.
 
+## Development
+
+### Setup
+
+```bash
+# Install PlatformIO
+pip install -r requirements.txt
+
+# Or with uv
+uv pip install -r requirements.txt
+```
+
+### Running Tests
+
+Tests run on desktop (native) without hardware using mocked Arduino/FastLED:
+
+```bash
+# Run all tests
+pio test -e native
+
+# Run specific test suite
+pio test -e native -f test_core
+
+# Verbose output
+pio test -e native -v
+```
+
+### Build Flags
+
+The core library uses these compile-time flags (set in `platformio.ini`):
+
+```ini
+build_flags = 
+    -D SENSOR_READ_INTERVAL_MS=10000  ; Sensor polling interval in ms (default: 10000)
+    -D FASTLED_DITHER_ENABLED=1       ; Enable FastLED temporal dithering (off by default)
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `SENSOR_READ_INTERVAL_MS` | 10000 | How often to read I2C sensors (BH1750, INA219) |
+| `FASTLED_DITHER_ENABLED` | off | Enable temporal dithering (can cause flicker at low brightness) |
+
+### Runtime Configuration
+
+These features are controlled at runtime via the controller API, allowing ESPHome and other integrations to configure them dynamically:
+
+```cpp
+controller->setAutoBrightnessEnabled(true);   // Enable BH1750 ambient light adjustment
+controller->setPowerMonitoringEnabled(true);  // Enable INA219 power logging
+Logger::setLogLevel(CoreLogLevel::VERBOSE);   // Enable verbose logging (FPS stats, etc.)
+```
+
+Downstream projects may use their own build flags to set defaults for these runtime options.
+
 ## Contributing
 
 Contributions are welcome! Please fork this repository and submit a pull request with your changes.
@@ -72,11 +154,4 @@ Contributions are welcome! Please fork this repository and submit a pull request
 ## License
 
 This project is licensed under the MIT License. See the `LICENSE` file for details.
-
----
-
-**To be continued** with:
-- Detailed usage examples
-- API documentation
-- Testing guidelines
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "siebenuhr_core",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Core functionality for the siebenuhr clock",
     "repository": {
       "type": "git",

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,26 @@
+; PlatformIO Configuration for siebenuhr_core
+; 
+; This file enables native (desktop) testing for the library.
+; Run tests with: pio test -e native
+;
+; The library itself is used by downstream projects (siebenuhr, siebenuhr_esphome)
+; via lib_deps - this platformio.ini is only for running tests.
+
+[env:native]
+platform = native
+test_framework = unity
+build_flags = 
+    -std=c++17
+    -DUNIT_TEST
+    -I test/mocks
+    -I src
+build_src_filter =
+    +<../test/mocks/>
+; test_filter = test_*  ; uncomment to filter specific tests
+lib_deps =
+lib_ignore =
+    FastLED
+    Wire
+    BH1750
+    Adafruit_INA219
+    RunningAverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Development dependencies for siebenuhr_core
+# Install with: pip install -r requirements.txt
+# Or with uv:   uv pip install -r requirements.txt
+
+platformio>=6.1.0

--- a/src/siebenuhr_button.cpp
+++ b/src/siebenuhr_button.cpp
@@ -30,7 +30,8 @@ namespace siebenuhr_core
         m_buttonPin = buttonPin;
         m_ledPin = ledPin;
 
-        // pinMode(m_ledPin, OUTPUT);
+        pinMode(m_ledPin, OUTPUT);
+        digitalWrite(m_ledPin, LOW);
         pinMode(m_buttonPin, INPUT_PULLUP);
         m_lastTransition = millis();
     }
@@ -98,7 +99,7 @@ namespace siebenuhr_core
         }
 
         m_lastState = reading;
-        // digitalWrite(m_ledPin, (m_state == LOW) ? HIGH : LOW);
+        digitalWrite(m_ledPin, (m_state == LOW) ? HIGH : LOW);
 
         return m_buttonState;
     }

--- a/src/siebenuhr_button.h
+++ b/src/siebenuhr_button.h
@@ -48,7 +48,7 @@ namespace siebenuhr_core {
     public:
         // Timing constants
         static constexpr unsigned long DEBOUNCE_DELAY = 50;    // ms
-        static constexpr unsigned long DOUBLE_CLICK_TIME = 350;  // ms
+        static constexpr unsigned long DOUBLE_CLICK_TIME = 250;  // ms - intentional double-clicks only
         static constexpr unsigned long LONG_PRESS_THRESHOLD = 500;  // ms
     };
 

--- a/src/siebenuhr_controller.cpp
+++ b/src/siebenuhr_controller.cpp
@@ -57,11 +57,14 @@ void BaseController::initialize(ClockType type)
 
 void BaseController::initializeControls()
 {
+    // Encoder: no feedback LED by default (only Controller PCB has nearby LED)
+    // Pass constants::LED3_PIN if encoder LED feedback is desired on Controller PCB
     m_encoder = new UIKnob(constants::ROT_ENC_A_PIN, constants::ROT_ENC_B_PIN, constants::ROT_ENC_BUTTON_PIN);
     m_encoder->setEncoderBoundaries(1, 255, 128, false);
 
-    m_button1 = new UIButton(constants::USER_BUTTON_PIN, constants::LED4_PIN);
-    m_button2 = new UIButton(constants::BOOT_BUTTON_PIN, constants::LED3_PIN);
+    // Button1 (User) = increment/up, Button2 (Boot) = decrement/down
+    m_button1 = new UIButton(constants::USER_BUTTON_PIN, constants::LED3_PIN);  // LED 3 near User Button
+    m_button2 = new UIButton(constants::BOOT_BUTTON_PIN, constants::LED2_PIN);  // LED 2 near Boot Button
 }
 
 Display* BaseController::getDisplay()
@@ -186,6 +189,7 @@ void BaseController::handleUserInput()
                 }
             }
 
+            #ifdef DOUBLE_CLICK_PERSONALITY_ENABLED
             // change personality on double click - handle FIRST to avoid triggering hue/brightness
             if (button1_state == ButtonState::DoubleClick) 
             {
@@ -197,6 +201,7 @@ void BaseController::handleUserInput()
                 getDisplay()->selectAdjacentPersonality(1);
                 return;
             }
+            #endif
 
             if (m_button1->isLongPress() && m_button2->isLongPress())
             {

--- a/src/siebenuhr_controller.cpp
+++ b/src/siebenuhr_controller.cpp
@@ -23,7 +23,7 @@ void BaseController::initialize(ClockType type)
     if (m_display != nullptr)
     {
         m_display->initialize(type, 4);
-        m_display->setHeartbeatEnabled(false);
+        m_display->setHeartbeatEnabled(true);
 
         m_currentColor = Color::fromCRGB(m_display->getColor());
 
@@ -82,7 +82,7 @@ void BaseController::setMenu(CONTROLLER_MENU menu)
     case CONTROLLER_MENU::BRIGHTNESS:
     {
         int current_brightness = getDisplay()->getBrightness();
-        m_encoder->setEncoderBoundaries(1, 255, current_brightness);
+        m_encoder->setEncoderBoundaries(1, 255, current_brightness);  // Min 1 for lowest brightness
         LOG_I("Switch to Option: %s, value=%d", m_menu[static_cast<int>(m_menuCurPos)].name.c_str(), current_brightness);
         break;
     }
@@ -185,6 +185,18 @@ void BaseController::handleUserInput()
                 }
             }
 
+            // change personality on double click - handle FIRST to avoid triggering hue/brightness
+            if (button1_state == ButtonState::DoubleClick) 
+            {
+                getDisplay()->selectAdjacentPersonality(-1);
+                return;
+            }
+            else if (button2_state == ButtonState::DoubleClick) 
+            {
+                getDisplay()->selectAdjacentPersonality(1);
+                return;
+            }
+
             if (m_button1->isLongPress() && m_button2->isLongPress())
             {
                 auto b1_press_time = millis() - m_button1->getLastPressEventTime();
@@ -220,17 +232,7 @@ void BaseController::handleUserInput()
                         setColor(m_currentColor);
                     }
                 }
-            }                  
-
-            // // change personality on double click
-            // else if (button1_state == ButtonState::DoubleClick) 
-            // {
-            //     getDisplay()->selectAdjacentPersonality(-1);
-            // }
-            // else if (button2_state == ButtonState::DoubleClick) 
-            // {
-            //     getDisplay()->selectAdjacentPersonality(1);
-            // }
+            }
         }
     }
 }
@@ -245,26 +247,29 @@ void BaseController::handleManualBrightnessChange()
     }
     else
     {
+        // Use non-linear step size based on current brightness
+        int step = getBrightnessStep(m_currentBrightness);
+        
         if (m_button1->isLongPress())
         {
-            brightness += 1;
+            brightness += 1;  // Fine control during long press
         }
         else if (m_button2->isLongPress())
         {
             brightness -= 1;
         }
-        if (m_button1->getState() == ButtonState::SingleClick || m_button1->getState() == ButtonState::DoubleClick)
+        else if (m_button1->getState() == ButtonState::SingleClick)
         {
-            brightness += 5;
+            brightness += step;
         }
-        else if (m_button2->getState() == ButtonState::SingleClick || m_button2->getState() == ButtonState::DoubleClick)
+        else if (m_button2->getState() == ButtonState::SingleClick)
         {
-            brightness -= 5;
+            brightness -= step;
         }
-        brightness = clamp(brightness, 5L, 255L);
+        brightness = clamp(brightness, 1L, 255L);  // Allow down to 1
     }
 
-    LOG_D("Brightness change: %d", brightness);
+    LOG_D("Brightness change: %d (step: %d)", brightness, getBrightnessStep(m_currentBrightness));
 
     // send state change back to home assistant server
     if (!sendBrightnessToHomeAssistant(brightness))
@@ -328,14 +333,30 @@ void BaseController::update(bool doHandleUserInput)
         handleUserInput();
     }
 
-    if (m_autoBrightnessEnabled && m_isBH1750Initialized) 
+    // Read sensors at regular intervals (avoid I2C polling every frame)
+    if (millis() - m_lastSensorReadTime >= constants::SensorReadInterval) 
     {
-        getDisplay()->setEnvLightLevel(g_bh1750.readLightLevel(), m_currentBrightness, 100);
-    }
+        m_lastSensorReadTime = millis();
 
-    if (m_powerMonitoringEnabled && m_isINA219Initialized)
-    {
-        readAndPrintPowerMonitoring();
+        if (m_isBH1750Initialized) 
+        {
+            float lux = g_bh1750.readLightLevel();
+            if (m_autoBrightnessEnabled) 
+            {
+                getDisplay()->setEnvLightLevel(lux, m_currentBrightness, 100);
+                LOG_D("BH1750: %.1f lux (base brightness: %d)", lux, m_currentBrightness);
+            }
+        }
+
+        if (m_powerMonitoringEnabled && m_isINA219Initialized)
+        {
+            float busvoltage = g_ina219.getBusVoltage_V();
+            float shuntvoltage = g_ina219.getShuntVoltage_mV();
+            float current_mA = shuntvoltage * 100.0;
+            float loadvoltage = busvoltage + (shuntvoltage / 1000.0);
+            float power_mW = busvoltage * current_mA;
+            LOG_D("INA219: %.2fV | %.2fmA | %.2fmW", loadvoltage, current_mA, power_mW);
+        }
     }
 
     getDisplay()->update();
@@ -346,8 +367,6 @@ void BaseController::setPower(bool powerEnabled)
     getDisplay()->setPowerEnabled(powerEnabled);
     LOG_D("Power set to %s", powerEnabled ? "ON" : "OFF");
 }
-
-// extern int remap_brightness(int value, float max, float _max);
 
 void BaseController::setBrightness(int value)
 {
@@ -375,7 +394,6 @@ void BaseController::setBrightness(int value)
                 m_encoder->setPosition(m_currentBrightness);
             }
 
-            // int m_value = remap_brightness(value, 255.f, 180.f);
             LOG_I("Brightness set to %d", value);
         }
     }
@@ -431,33 +449,6 @@ void BaseController::setPersonality(PersonalityType personality)
     if (m_display != nullptr)
     {
         m_display->setPersonality(personality);
-    }
-}
-
-void BaseController::readAndPrintPowerMonitoring()
-{
-    if (millis() - m_lastSensorReadTime >= constants::SensorReadInterval) 
-    {
-        float busvoltage = g_ina219.getBusVoltage_V();
-        float shuntvoltage = g_ina219.getShuntVoltage_mV();  // in mV
-        float current_mA = shuntvoltage * 100.0;           // for 10 mΩ shunt
-        float loadvoltage = busvoltage + (shuntvoltage / 1000.0); // in V
-        float power_mW = busvoltage * current_mA;          // V * mA = mW
-
-        bool current_in_A = abs(current_mA) >= 500.0;
-        bool power_in_W = abs(power_mW) >= 500.0;
-
-        LOG_I("Bus: %.2fV | Shunt: %.2fmV | Load: %.2fV | Current: %.2f%s | Power: %.2f%s", 
-            busvoltage, 
-            shuntvoltage, 
-            loadvoltage, 
-            current_in_A?(current_mA / 1000.0):current_mA, 
-            current_in_A?"A":"mA",
-            power_in_W?(power_mW / 1000.0):power_mW,
-            power_in_W?"W":"mW"
-        );
-        
-        m_lastSensorReadTime = millis();
     }
 }
 

--- a/src/siebenuhr_controller.cpp
+++ b/src/siebenuhr_controller.cpp
@@ -16,6 +16,7 @@ const BaseController::ControllerMenu_t BaseController::m_menu[BaseController::m_
 void BaseController::initialize(ClockType type)
 {
     Logger::init("🚀 siebenuhr.core");
+    LOG_I("siebenuhr_core v%s", SIEBENUHR_CORE_VERSION);
 
     m_clockType = type;
 

--- a/src/siebenuhr_controller.h
+++ b/src/siebenuhr_controller.h
@@ -91,7 +91,6 @@ private:
     void setMenu(CONTROLLER_MENU menu);
     void handleManualBrightnessChange();
     void handleManualHueChange();
-    void readAndPrintPowerMonitoring();
 
     unsigned long m_lastSimultaneousClickTime = 0;
 

--- a/src/siebenuhr_core.h
+++ b/src/siebenuhr_core.h
@@ -11,13 +11,12 @@ namespace siebenuhr_core
 {
     namespace constants 
     {
-        // SolidDifference Board GPIO
-        constexpr int LED2_PIN = 22; // next to the BH1750 sensor
-        constexpr int LED3_PIN = 19; // next to the INA219 sensor
-        constexpr int LED4_PIN = 23; // next to user button
-
-        constexpr int LED_HEARTBEAT_PIN = LED2_PIN;
-        constexpr int LED_GLYPH_PIN = 21;
+        // SolidDifference Board GPIO - PWM LEDs
+        constexpr int LED2_PIN = 22;             // PWM LED 2
+        constexpr int LED3_PIN = 19;             // PWM LED 3 - near Boot Button
+        constexpr int LED4_PIN = 23;             // PWM LED 4 - near User Button
+        constexpr int LED_HEARTBEAT_PIN = 5;     // PWM Heartbeat LED (orange)
+        constexpr int LED_GLYPH_PIN = 21;        // FastLED RGB strip
 
         constexpr int USER_BUTTON_PIN = 33;
         constexpr int BOOT_BUTTON_PIN = 0;
@@ -56,7 +55,10 @@ namespace siebenuhr_core
         constexpr CRGB BLACK = CRGB(0, 0, 0);
 
         // sensors
-        constexpr int SensorReadInterval = 2000;
+        #ifndef SENSOR_READ_INTERVAL_MS
+        #define SENSOR_READ_INTERVAL_MS 10000
+        #endif
+        constexpr int SensorReadInterval = SENSOR_READ_INTERVAL_MS;
     }
 
     enum ClockType {
@@ -90,5 +92,19 @@ namespace siebenuhr_core
             return minValue;
         }
         return value;
+    }
+
+    // Brightness: non-linear scaling for better control
+    // available to both PlatformIO and ESPHome versions
+    
+    // Get appropriate step size based on current brightness level
+    // High brightness (>100): coarse steps (10)
+    // Medium brightness (20-100): medium steps (5)  
+    // Low brightness (<20): fine steps (1)
+    inline int getBrightnessStep(int currentBrightness)
+    {
+        if (currentBrightness > 100) return 10;
+        if (currentBrightness > 20) return 5;
+        return 1;
     }
 }

--- a/src/siebenuhr_core.h
+++ b/src/siebenuhr_core.h
@@ -11,12 +11,12 @@ namespace siebenuhr_core
 {
     namespace constants 
     {
-        // SolidDifference Board GPIO - PWM LEDs
-        constexpr int LED2_PIN = 22;             // PWM LED 2
-        constexpr int LED3_PIN = 19;             // PWM LED 3 - near Boot Button
-        constexpr int LED4_PIN = 23;             // PWM LED 4 - near User Button
-        constexpr int LED_HEARTBEAT_PIN = 5;     // PWM Heartbeat LED (orange)
-        constexpr int LED_GLYPH_PIN = 21;        // FastLED RGB strip
+        // SolidDifference Board GPIO - PWM LEDs (names match board silk screen)
+        constexpr int LED1_PIN = 22;             // LED 1 - near BH1750 (calibration)
+        constexpr int LED2_PIN = 19;             // LED 2 - near Boot Button (decrement)
+        constexpr int LED3_PIN = 23;             // LED 3 - near User Button (increment)
+        constexpr int LED_HEARTBEAT_PIN = 5;     // Heartbeat LED (orange)
+        constexpr int LED_GLYPH_PIN = 21;        // DOUT - FastLED RGB strip
 
         constexpr int USER_BUTTON_PIN = 33;
         constexpr int BOOT_BUTTON_PIN = 0;

--- a/src/siebenuhr_core.h
+++ b/src/siebenuhr_core.h
@@ -5,7 +5,7 @@
 
 #include "siebenuhr_logger.h"
 
-#define SIEBENUHR_CORE_VERSION "1.0.10"
+#define SIEBENUHR_CORE_VERSION "1.1.0"
 
 namespace siebenuhr_core
 {

--- a/src/siebenuhr_display.cpp
+++ b/src/siebenuhr_display.cpp
@@ -54,9 +54,20 @@ namespace siebenuhr_core
     void Display::setHeartbeatEnabled(bool isEnabled) 
     {
         m_heartbeatEnabled = isEnabled;
+        
+        // Always configure pin as output to ensure known state
+        pinMode(constants::LED_HEARTBEAT_PIN, OUTPUT);
+        
         if (m_heartbeatEnabled)
         {
-            pinMode(constants::LED_HEARTBEAT_PIN, OUTPUT);
+            m_heartbeatState = false;
+            m_lastHeartbeatTime = millis();
+            analogWrite(constants::LED_HEARTBEAT_PIN, 0);
+        }
+        else
+        {
+            // Turn off LED when heartbeat is disabled
+            analogWrite(constants::LED_HEARTBEAT_PIN, 0);
         }
     }
 
@@ -87,6 +98,11 @@ namespace siebenuhr_core
         }
 
 		FastLED.addLeds<WS2812, constants::LED_GLYPH_PIN, GRB>(m_LEDs, m_numLEDs);      
+        #ifdef FASTLED_DITHER_ENABLED
+        FastLED.setDither(1);  // Enable temporal dithering (may flicker at low brightness)
+        #else
+        FastLED.setDither(0);  // Disable dithering by default for stable low-brightness display
+        #endif
         FastLED.clear(true);
 
         m_lastUpdateMillis = millis();
@@ -129,36 +145,30 @@ namespace siebenuhr_core
         return brightness;
     }
 
-    // void Display::setEnvLightLevel(float currentLux, int minBrightness, int maxBrightness)
     void Display::setEnvLightLevel(float currentLux, int baseBrightness, int maxBrightnessRange)
     {
         if (m_powerEnabled) 
         {
-            uint8_t brightness = getSmoothedBrightnessFromLux(currentLux, maxBrightnessRange);
+            uint8_t envBrightness = getSmoothedBrightnessFromLux(currentLux, maxBrightnessRange);
+            int new_brightness = clamp(baseBrightness + (int)envBrightness, 1, 255);
 
-            int new_brightness = clamp(baseBrightness + brightness, 0, 255);
-
+            // FastLED handles gamma internally - pass value directly
             FastLED.setBrightness(new_brightness);
-
-            // logMessage(LOG_LEVEL_INFO, "Base: %d Smoothed: %d Brightness: %d", baseBrightness, brightness, new_brightness);
+            FastLED.show();
         }
-    }
-
-    int remap_brightness(int value, float max)
-    {
-        return (int)(((float)value / max) * 180.f);
     }
 
     int Display::setBrightness(int value) 
     {
-        value = clamp(value, 0, 255);
-
+        value = clamp(value, 1, 255);  // Min 1 for dimmest setting
         m_brightness = value;
 
-        int m_value = remap_brightness(m_brightness, 255.f);
-        FastLED.setBrightness(m_value);
+        // FastLED handles gamma correction and temporal dithering internally
+        // Just pass the value directly - no additional scaling needed
+        FastLED.setBrightness(m_brightness);
+        FastLED.show();  // Apply immediately for responsive feel
 
-        LOG_D("Display Brightness: %d (%d)", m_brightness, m_value);
+        LOG_D("Display Brightness: %d", m_brightness);
         return m_brightness;
     }
 
@@ -406,15 +416,22 @@ namespace siebenuhr_core
             FastLED.show();
         }
 
-        // update heartbeat led
+        // update heartbeat led (dim PWM blink)
         if (m_heartbeatEnabled && (currentMillis - m_lastHeartbeatTime >= m_heartbeatInterval)) {
             m_lastHeartbeatTime = currentMillis;
             m_heartbeatState = !m_heartbeatState;
-            digitalWrite(constants::LED_HEARTBEAT_PIN, m_heartbeatState);
+            analogWrite(constants::LED_HEARTBEAT_PIN, m_heartbeatState ? 25 : 0);  // ~10% brightness
         }
 
         m_avgComputionTime.addValue(currentMillis - m_lastUpdateMillis);
         m_lastUpdateMillis = currentMillis;
+
+        // Log FPS periodically (every 5 seconds) - verbose only
+        static unsigned long lastFpsLogTime = 0;
+        if (currentMillis - lastFpsLogTime >= 5000) {
+            lastFpsLogTime = currentMillis;
+            LOG_V("FastLED FPS: %d, avg frame time: %.1fms", FastLED.getFPS(), m_avgComputionTime.getAverage());
+        }
     }
 
 }

--- a/src/siebenuhr_encoder.cpp
+++ b/src/siebenuhr_encoder.cpp
@@ -15,13 +15,21 @@ namespace siebenuhr_core
         m_rotaryEncoder->readButton_ISR();
     }
 
-    UIKnob::UIKnob(uint8_t encoderPinA, uint8_t encoderPinB, uint8_t buttonPin) 
+    UIKnob::UIKnob(uint8_t encoderPinA, uint8_t encoderPinB, uint8_t buttonPin, int8_t feedbackLedPin) 
+        : m_feedbackLedPin(feedbackLedPin)
     {
         m_rotaryEncoder = new AiEsp32RotaryEncoder(encoderPinA, encoderPinB, buttonPin, -1, ROTARY_ENCODER_STEPS);
         m_rotaryEncoder->begin();
         m_rotaryEncoder->setup(handleEncoderInterrupt, handleButtonInterrupt);
         m_rotaryEncoder->setBoundaries(0, 255, false); //minValue, maxValue, circleValues true|false (when max go to min and vice versa)
         m_rotaryEncoder->setAcceleration(250);
+
+        // Initialize LED pin for encoder button feedback (if configured)
+        if (m_feedbackLedPin >= 0) 
+        {
+            pinMode(m_feedbackLedPin, OUTPUT);
+            digitalWrite(m_feedbackLedPin, LOW);
+        }
 
         m_encoderPosition = 0;
         m_encoderPositionDiff = 0;
@@ -39,13 +47,17 @@ namespace siebenuhr_core
         m_buttonPressedState = m_rotaryEncoder->isEncoderButtonDown();
 
         if (isButtonPressed()) {
-            digitalWrite(constants::LED2_PIN, HIGH);
+            if (m_feedbackLedPin >= 0) {
+                digitalWrite(m_feedbackLedPin, HIGH);
+            }
             if (!m_buttonPrevPressedState) {
                 m_buttonPrevPressedState = true;
                 m_buttonPressedTime = millis();
             }
         } else {
-            digitalWrite(constants::LED2_PIN, LOW);
+            if (m_feedbackLedPin >= 0) {
+                digitalWrite(m_feedbackLedPin, LOW);
+            }
             m_buttonPrevPressedState = false;
         }	
     }

--- a/src/siebenuhr_encoder.h
+++ b/src/siebenuhr_encoder.h
@@ -8,7 +8,8 @@ namespace siebenuhr_core {
 
     class UIKnob {
     public:
-        UIKnob(uint8_t encoderPinA, uint8_t encoderPinB, uint8_t buttonPin);
+        // feedbackLedPin: GPIO pin for button press feedback LED, or -1 to disable
+        UIKnob(uint8_t encoderPinA, uint8_t encoderPinB, uint8_t buttonPin, int8_t feedbackLedPin = -1);
         ~UIKnob();
 
         void update();
@@ -28,6 +29,7 @@ namespace siebenuhr_core {
         static void IRAM_ATTR handleButtonInterrupt();
 
     private:
+        int8_t m_feedbackLedPin;
         bool m_buttonPressedState;
         bool m_buttonPrevPressedState;
         long m_buttonPressedTime; 

--- a/src/siebenuhr_logger.h
+++ b/src/siebenuhr_logger.h
@@ -52,8 +52,11 @@ public:
     static void setLogLevel(CoreLogLevel level) {
         s_log_level = level;
 
-        String levelName = "NONE";
+        String levelName;
         switch (level) {
+            case CoreLogLevel::NONE:
+                levelName = "NONE";
+                break;
             case CoreLogLevel::ERROR:
                 levelName = "ERROR";
                 break;

--- a/src/siebenuhr_logger.h
+++ b/src/siebenuhr_logger.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdarg>
 #include <Arduino.h>
 #include "esp_log.h"
 

--- a/test/mocks/Arduino.h
+++ b/test/mocks/Arduino.h
@@ -1,0 +1,71 @@
+// Mock Arduino.h for native testing
+// Provides minimal stubs for Arduino types and functions
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+// Arduino types
+typedef uint8_t byte;
+typedef bool boolean;
+
+// Pin modes
+#define INPUT 0
+#define OUTPUT 1
+#define INPUT_PULLUP 2
+
+// Digital values
+#define HIGH 1
+#define LOW 0
+
+// Math macros
+#ifndef PI
+#define PI 3.14159265358979323846
+#endif
+
+// Stub functions
+inline void pinMode(uint8_t pin, uint8_t mode) { (void)pin; (void)mode; }
+inline void digitalWrite(uint8_t pin, uint8_t val) { (void)pin; (void)val; }
+inline int digitalRead(uint8_t pin) { (void)pin; return LOW; }
+inline int analogRead(uint8_t pin) { (void)pin; return 0; }
+inline void analogWrite(uint8_t pin, int val) { (void)pin; (void)val; }
+inline void delay(unsigned long ms) { (void)ms; }
+inline void delayMicroseconds(unsigned int us) { (void)us; }
+
+// Time - test harness can override these
+static unsigned long _mock_millis = 0;
+inline unsigned long millis() { return _mock_millis; }
+inline unsigned long micros() { return _mock_millis * 1000; }
+inline void _set_mock_millis(unsigned long ms) { _mock_millis = ms; }
+
+// String class (simplified)
+class String {
+public:
+    String() : _str() {}
+    String(const char* s) : _str(s ? s : "") {}
+    String(const std::string& s) : _str(s) {}
+    String(int val) : _str(std::to_string(val)) {}
+    
+    const char* c_str() const { return _str.c_str(); }
+    size_t length() const { return _str.length(); }
+    bool operator==(const String& other) const { return _str == other._str; }
+    String& operator+=(const String& other) { _str += other._str; return *this; }
+    String operator+(const String& other) const { return String(_str + other._str); }
+    
+private:
+    std::string _str;
+};
+
+// Serial stub
+class MockSerial {
+public:
+    void begin(unsigned long baud) { (void)baud; }
+    void print(const char* s) { printf("%s", s); }
+    void print(int n) { printf("%d", n); }
+    void println(const char* s = "") { printf("%s\n", s); }
+    void println(int n) { printf("%d\n", n); }
+};
+
+extern MockSerial Serial;

--- a/test/mocks/FastLED.h
+++ b/test/mocks/FastLED.h
@@ -1,0 +1,83 @@
+// Mock FastLED.h for native testing
+// Provides CRGB and related types without hardware dependencies
+#pragma once
+
+#include <cstdint>
+#include <algorithm>
+
+// Forward declarations
+struct CRGB;
+struct CHSV;
+
+// CRGB - RGB color (constexpr-compatible for native tests)
+struct CRGB {
+    uint8_t r, g, b;
+    
+    constexpr CRGB() : r(0), g(0), b(0) {}
+    constexpr CRGB(uint8_t r_, uint8_t g_, uint8_t b_) : r(r_), g(g_), b(b_) {}
+    constexpr CRGB(uint32_t colorcode) 
+        : r((colorcode >> 16) & 0xFF)
+        , g((colorcode >> 8) & 0xFF)
+        , b(colorcode & 0xFF) {}
+    
+    constexpr bool operator==(const CRGB& other) const {
+        return r == other.r && g == other.g && b == other.b;
+    }
+    constexpr bool operator!=(const CRGB& other) const { return !(*this == other); }
+    
+    // Named colors - declared here, defined after struct is complete
+    static const CRGB Black;
+    static const CRGB White;
+    static const CRGB Red;
+    static const CRGB Green;
+    static const CRGB Blue;
+};
+
+// Define static colors after CRGB is complete
+inline constexpr CRGB CRGB::Black{0, 0, 0};
+inline constexpr CRGB CRGB::White{255, 255, 255};
+inline constexpr CRGB CRGB::Red{255, 0, 0};
+inline constexpr CRGB CRGB::Green{0, 255, 0};
+inline constexpr CRGB CRGB::Blue{0, 0, 255};
+
+// CHSV - HSV color
+struct CHSV {
+    uint8_t h, s, v;
+    CHSV() : h(0), s(0), v(0) {}
+    CHSV(uint8_t h, uint8_t s, uint8_t v) : h(h), s(s), v(v) {}
+};
+
+// lerp8by8 - linear interpolation
+inline uint8_t lerp8by8(uint8_t a, uint8_t b, uint8_t frac) {
+    int result = a + (((int)(b - a) * frac) >> 8);
+    return (uint8_t)result;
+}
+
+// Mock FastLED controller class
+class CFastLED {
+public:
+    template<typename CHIPSET, uint8_t DATA_PIN, uint8_t COLOR_ORDER>
+    static void addLeds(CRGB* data, int nLedsOrOffset, int nLedsIfOffset = 0) {
+        (void)data; (void)nLedsOrOffset; (void)nLedsIfOffset;
+    }
+    
+    static void setBrightness(uint8_t scale) { _brightness = scale; }
+    static uint8_t getBrightness() { return _brightness; }
+    static void setDither(uint8_t dither) { (void)dither; }
+    static uint16_t getFPS() { return 30; }
+    static void show() {}
+    static void clear(bool writeData = false) { (void)writeData; }
+    
+private:
+    static uint8_t _brightness;
+};
+
+inline uint8_t CFastLED::_brightness = 255;
+
+extern CFastLED FastLED;
+
+// LED chipset types (stubs)
+#define WS2812 0
+#define WS2812B 1
+#define GRB 0
+#define RGB 1

--- a/test/mocks/esp_log.h
+++ b/test/mocks/esp_log.h
@@ -1,0 +1,18 @@
+// Mock esp_log.h for native testing
+#pragma once
+
+// ESP log levels
+typedef enum {
+    ESP_LOG_NONE = 0,
+    ESP_LOG_ERROR,
+    ESP_LOG_WARN,
+    ESP_LOG_INFO,
+    ESP_LOG_DEBUG,
+    ESP_LOG_VERBOSE
+} esp_log_level_t;
+
+// Stub functions
+inline void esp_log_level_set(const char* tag, esp_log_level_t level) {
+    (void)tag;
+    (void)level;
+}

--- a/test/mocks/mocks.cpp
+++ b/test/mocks/mocks.cpp
@@ -1,0 +1,11 @@
+// Implementation file for mock stubs
+// Required for linker to find definitions
+
+#include "Arduino.h"
+#include "FastLED.h"
+
+// Arduino mock implementations
+MockSerial Serial;
+
+// FastLED mock implementations  
+CFastLED FastLED;

--- a/test/test_color/test_color.cpp
+++ b/test/test_color/test_color.cpp
@@ -1,0 +1,119 @@
+// Tests for siebenuhr_core::Color class
+// Focus: initialization, RGB/hue conversion, edge cases
+#include <unity.h>
+#include <cmath>
+#include "siebenuhr_color.h"
+
+using namespace siebenuhr_core;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ============================================================================
+// Initialization & Conversion
+// ============================================================================
+
+void test_default_is_black() {
+    Color c;
+    CRGB rgb = c.getCRGB();
+    TEST_ASSERT_EQUAL_UINT8(0, rgb.r);
+    TEST_ASSERT_EQUAL_UINT8(0, rgb.g);
+    TEST_ASSERT_EQUAL_UINT8(0, rgb.b);
+}
+
+void test_crgb_roundtrip() {
+    // CRGB -> Color -> CRGB should preserve values
+    CRGB input(100, 150, 200);
+    CRGB output = Color::fromCRGB(input).getCRGB();
+    TEST_ASSERT_EQUAL_UINT8(input.r, output.r);
+    TEST_ASSERT_EQUAL_UINT8(input.g, output.g);
+    TEST_ASSERT_EQUAL_UINT8(input.b, output.b);
+}
+
+// ============================================================================
+// Hue
+// ============================================================================
+
+void test_primary_hues() {
+    // Red=0°, Green=120°, Blue=240°
+    CRGB red = Color::fromHue(0.0f).getCRGB();
+    CRGB green = Color::fromHue(120.0f).getCRGB();
+    CRGB blue = Color::fromHue(240.0f).getCRGB();
+    
+    TEST_ASSERT_EQUAL_UINT8(255, red.r);
+    TEST_ASSERT_EQUAL_UINT8(255, green.g);
+    TEST_ASSERT_EQUAL_UINT8(255, blue.b);
+}
+
+void test_hue_wraps_at_360() {
+    // 360° should equal 0° (both red)
+    CRGB at360 = Color::fromHue(360.0f).getCRGB();
+    CRGB at0 = Color::fromHue(0.0f).getCRGB();
+    TEST_ASSERT_EQUAL_UINT8(at0.r, at360.r);
+    TEST_ASSERT_EQUAL_UINT8(at0.g, at360.g);
+    TEST_ASSERT_EQUAL_UINT8(at0.b, at360.b);
+}
+
+void test_adjust_hue_wraps_positive() {
+    Color c = Color::fromHue(350.0f);
+    c.adjustHueBy(20.0f);  // 350 + 20 = 370 -> 10
+    TEST_ASSERT_FLOAT_WITHIN(2.0f, 10.0f, c.getHue());
+}
+
+void test_adjust_hue_wraps_negative() {
+    Color c = Color::fromHue(5.0f);
+    c.adjustHueBy(-15.0f);  // 5 - 15 = -10 -> 350
+    TEST_ASSERT_FLOAT_WITHIN(2.0f, 350.0f, c.getHue());
+}
+
+void test_get_hue_from_rgb() {
+    // Verify getHue() extracts correct hue from known RGB values
+    TEST_ASSERT_FLOAT_WITHIN(2.0f, 0.0f, Color(1.0f, 0.0f, 0.0f).getHue());    // Red
+    TEST_ASSERT_FLOAT_WITHIN(2.0f, 120.0f, Color(0.0f, 1.0f, 0.0f).getHue());  // Green
+    TEST_ASSERT_FLOAT_WITHIN(2.0f, 240.0f, Color(0.0f, 0.0f, 1.0f).getHue());  // Blue
+}
+
+// ============================================================================
+// Brightness
+// ============================================================================
+
+void test_brightness_scales_output() {
+    Color full = Color::fromHue(0.0f, 1.0f);
+    Color half = Color::fromHue(0.0f, 0.5f);
+    
+    TEST_ASSERT_FLOAT_WITHIN(0.05f, 1.0f, full.getBrightness());
+    TEST_ASSERT_FLOAT_WITHIN(0.05f, 0.5f, half.getBrightness());
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+void test_rgb_values_clamped() {
+    // Out-of-range values should clamp to [0, 255]
+    Color c(2.0f, -0.5f, 1.0f);
+    CRGB rgb = c.getCRGB();
+    TEST_ASSERT_EQUAL_UINT8(255, rgb.r);  // 2.0 -> 1.0 -> 255
+    TEST_ASSERT_EQUAL_UINT8(0, rgb.g);    // -0.5 -> 0.0 -> 0
+    TEST_ASSERT_EQUAL_UINT8(255, rgb.b);
+}
+
+// ============================================================================
+// Test Runner
+// ============================================================================
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    
+    RUN_TEST(test_default_is_black);
+    RUN_TEST(test_crgb_roundtrip);
+    RUN_TEST(test_primary_hues);
+    RUN_TEST(test_hue_wraps_at_360);
+    RUN_TEST(test_adjust_hue_wraps_positive);
+    RUN_TEST(test_adjust_hue_wraps_negative);
+    RUN_TEST(test_get_hue_from_rgb);
+    RUN_TEST(test_brightness_scales_output);
+    RUN_TEST(test_rgb_values_clamped);
+    
+    return UNITY_END();
+}

--- a/test/test_core/test_core.cpp
+++ b/test/test_core/test_core.cpp
@@ -1,0 +1,122 @@
+// Tests for siebenuhr_core.h
+// Focus: public constants, utility functions, type definitions
+#include <unity.h>
+#include "siebenuhr_core.h"
+
+using namespace siebenuhr_core;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ============================================================================
+// Public Interface - Constants
+// These tests verify the expected public API is present and sensible
+// ============================================================================
+
+void test_clock_types_defined() {
+    // Verify ClockType enum values exist
+    TEST_ASSERT_EQUAL(0, CLOCK_TYPE_REGULAR);
+    TEST_ASSERT_EQUAL(1, CLOCK_TYPE_MINI);
+}
+
+void test_personality_types_complete() {
+    // Verify all expected personality types exist in sequence
+    TEST_ASSERT_EQUAL(0, PERSONALITY_SOLIDCOLOR);
+    TEST_ASSERT_EQUAL(1, PERSONALITY_COLORWHEEL);
+    TEST_ASSERT_EQUAL(2, PERSONALITY_RAINBOW);
+    TEST_ASSERT_EQUAL(3, PERSONALITY_MOSAIK);
+    TEST_ASSERT_EQUAL(4, PERSONALITY_GLITTER);
+    TEST_ASSERT_EQUAL(5, PERSONALITY_END);  // Sentinel value
+}
+
+void test_display_constants() {
+    // Core display parameters
+    TEST_ASSERT_EQUAL(4, constants::GlyphCount);
+    TEST_ASSERT_EQUAL(7, constants::SegmentCount);
+    TEST_ASSERT_TRUE(constants::FPS > 0);
+    TEST_ASSERT_TRUE(constants::DefaultBrightness > 0);
+    TEST_ASSERT_TRUE(constants::DefaultBrightness <= 255);
+}
+
+void test_led_counts() {
+    // Mini vs Regular clock LED counts
+    TEST_ASSERT_TRUE(constants::MiniLedsPerSegment > 0);
+    TEST_ASSERT_TRUE(constants::RegularLedsPerSegment > 0);
+    TEST_ASSERT_TRUE(constants::RegularLedsPerSegment > constants::MiniLedsPerSegment);
+}
+
+void test_total_led_calculation() {
+    // Total LEDs = Glyphs × Segments × LEDs per segment
+    int miniTotal = constants::GlyphCount * constants::SegmentCount * constants::MiniLedsPerSegment;
+    int regularTotal = constants::GlyphCount * constants::SegmentCount * constants::RegularLedsPerSegment;
+    
+    TEST_ASSERT_EQUAL(4 * 7 * 4, miniTotal);    // 112 LEDs for mini
+    TEST_ASSERT_EQUAL(4 * 7 * 17, regularTotal); // 476 LEDs for regular
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+void test_clamp_boundaries() {
+    // Clamp should constrain values to range
+    TEST_ASSERT_EQUAL(0, clamp(-50, 0, 100));
+    TEST_ASSERT_EQUAL(50, clamp(50, 0, 100));
+    TEST_ASSERT_EQUAL(100, clamp(150, 0, 100));
+}
+
+void test_brightness_step_thresholds() {
+    // Non-linear step sizes: fine control at low brightness
+    TEST_ASSERT_EQUAL(1, getBrightnessStep(10));   // Low: fine
+    TEST_ASSERT_EQUAL(5, getBrightnessStep(50));   // Medium: medium
+    TEST_ASSERT_EQUAL(10, getBrightnessStep(150)); // High: coarse
+}
+
+void test_brightness_step_boundaries() {
+    // Verify boundary conditions
+    TEST_ASSERT_EQUAL(1, getBrightnessStep(1));    // Min brightness
+    TEST_ASSERT_EQUAL(1, getBrightnessStep(20));   // Boundary: still fine
+    TEST_ASSERT_EQUAL(5, getBrightnessStep(21));   // Just above threshold
+    TEST_ASSERT_EQUAL(5, getBrightnessStep(100));  // Boundary: still medium
+    TEST_ASSERT_EQUAL(10, getBrightnessStep(101)); // Just above threshold
+    TEST_ASSERT_EQUAL(10, getBrightnessStep(255)); // Max brightness
+}
+
+// ============================================================================
+// LEDAnimationState Structure
+// ============================================================================
+
+void test_animation_state_fields() {
+    LEDAnimationState state = {};
+    state.isActive = true;
+    state.duration = 500;
+    state.startTime = 1000;
+    
+    TEST_ASSERT_TRUE(state.isActive);
+    TEST_ASSERT_EQUAL(500, state.duration);
+}
+
+// ============================================================================
+// Test Runner
+// ============================================================================
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    
+    // Public interface
+    RUN_TEST(test_clock_types_defined);
+    RUN_TEST(test_personality_types_complete);
+    RUN_TEST(test_display_constants);
+    RUN_TEST(test_led_counts);
+    RUN_TEST(test_total_led_calculation);
+    
+    // Utilities
+    RUN_TEST(test_clamp_boundaries);
+    RUN_TEST(test_brightness_step_thresholds);
+    RUN_TEST(test_brightness_step_boundaries);
+    
+    // Types
+    RUN_TEST(test_animation_state_fields);
+    
+    return UNITY_END();
+}

--- a/test/test_glyph/test_glyph.cpp
+++ b/test/test_glyph/test_glyph.cpp
@@ -1,0 +1,130 @@
+// Tests for ASCII_TABLE and DIGIT lookups in siebenuhr_glyph.h
+// These are header-only constants - no .cpp linkage needed
+#include <unity.h>
+#include "siebenuhr_glyph.h"
+
+using namespace siebenuhr_core;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ============================================================================
+// ASCII Table - Digit Patterns (0-9)
+// ============================================================================
+
+void test_digit_segment_counts() {
+    // Each digit 0-9 should have between 2-7 active segments
+    for (int digit = 0; digit <= 9; digit++) {
+        int ascii = '0' + digit;
+        int activeCount = 0;
+        for (int seg = 0; seg < 7; seg++) {
+            if (ASCII_TABLE[ascii][seg] != 0) activeCount++;
+        }
+        TEST_ASSERT_TRUE_MESSAGE(activeCount >= 2, "Digit should have at least 2 segments");
+        TEST_ASSERT_TRUE_MESSAGE(activeCount <= 7, "Digit should have at most 7 segments");
+    }
+}
+
+void test_digit_8_all_segments() {
+    // '8' should light all 7 segments
+    for (int seg = 0; seg < 7; seg++) {
+        TEST_ASSERT_EQUAL_INT(1, ASCII_TABLE['8'][seg]);
+    }
+}
+
+void test_digit_1_two_segments() {
+    // '1' should have exactly 2 segments
+    int count = 0;
+    for (int seg = 0; seg < 7; seg++) {
+        if (ASCII_TABLE['1'][seg] != 0) count++;
+    }
+    TEST_ASSERT_EQUAL_INT(2, count);
+}
+
+void test_digits_match_DIGIT_array() {
+    // ASCII_TABLE['0'-'9'] should match DIGIT[0-9]
+    for (int d = 0; d <= 9; d++) {
+        for (int seg = 0; seg < 7; seg++) {
+            TEST_ASSERT_EQUAL_INT(DIGIT[d][seg], ASCII_TABLE['0' + d][seg]);
+        }
+    }
+}
+
+// ============================================================================
+// ASCII Table - Special Characters
+// ============================================================================
+
+void test_space_is_blank() {
+    // ' ' (space) should have no segments
+    for (int seg = 0; seg < 7; seg++) {
+        TEST_ASSERT_EQUAL_INT(0, ASCII_TABLE[' '][seg]);
+    }
+}
+
+void test_minus_is_middle_segment() {
+    // '-' typically lights only the middle segment (index varies by layout)
+    int count = 0;
+    for (int seg = 0; seg < 7; seg++) {
+        if (ASCII_TABLE['-'][seg] != 0) count++;
+    }
+    TEST_ASSERT_EQUAL_INT(1, count);  // Only middle segment
+}
+
+// ============================================================================
+// ASCII Table - Letters
+// ============================================================================
+
+void test_common_letters_have_patterns() {
+    // Letters commonly used in clock displays should have patterns
+    const char* letters = "AbCdEFgHiJLnoPqrtUy";
+    for (int i = 0; letters[i] != '\0'; i++) {
+        int ascii = letters[i];
+        int count = 0;
+        for (int seg = 0; seg < 7; seg++) {
+            if (ASCII_TABLE[ascii][seg] != 0) count++;
+        }
+        TEST_ASSERT_TRUE_MESSAGE(count > 0, "Letter should have at least 1 segment");
+    }
+}
+
+// ============================================================================
+// ASCII Table - Bounds
+// ============================================================================
+
+void test_ascii_table_size() {
+    // Table should cover ASCII 0-126
+    // Just verify we can access without crash
+    int sum = 0;
+    for (int i = 0; i < 127; i++) {
+        for (int seg = 0; seg < 7; seg++) {
+            sum += ASCII_TABLE[i][seg];
+        }
+    }
+    TEST_ASSERT_TRUE(sum > 0);  // Some segments should be set
+}
+
+// ============================================================================
+// Test Runner
+// ============================================================================
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    
+    // Digits
+    RUN_TEST(test_digit_segment_counts);
+    RUN_TEST(test_digit_8_all_segments);
+    RUN_TEST(test_digit_1_two_segments);
+    RUN_TEST(test_digits_match_DIGIT_array);
+    
+    // Special characters
+    RUN_TEST(test_space_is_blank);
+    RUN_TEST(test_minus_is_middle_segment);
+    
+    // Letters
+    RUN_TEST(test_common_letters_have_patterns);
+    
+    // Bounds
+    RUN_TEST(test_ascii_table_size);
+    
+    return UNITY_END();
+}

--- a/test/test_logger/test_logger.cpp
+++ b/test/test_logger/test_logger.cpp
@@ -1,0 +1,197 @@
+// Tests for siebenuhr_core::Logger
+// Focus: log level ordering, level filtering, format safety
+#include <unity.h>
+#include "siebenuhr_logger.h"
+
+// Define static members for test (normally in siebenuhr_logger.cpp)
+namespace siebenuhr_core {
+    const char* Logger::s_tag = "test";
+    CoreLogLevel Logger::s_log_level = CoreLogLevel::INFO;
+}
+
+using namespace siebenuhr_core;
+
+void setUp(void) {
+    // Reset to known state before each test
+    Logger::setLogLevel(CoreLogLevel::INFO);
+}
+
+void tearDown(void) {}
+
+// ============================================================================
+// CoreLogLevel Enum - Ordering
+// Level filtering depends on numeric ordering: NONE < ERROR < WARN < INFO < DEBUG < VERBOSE
+// ============================================================================
+
+void test_log_levels_ordered() {
+    // Verify levels are in ascending order for filtering to work
+    TEST_ASSERT_TRUE(CoreLogLevel::NONE < CoreLogLevel::ERROR);
+    TEST_ASSERT_TRUE(CoreLogLevel::ERROR < CoreLogLevel::WARN);
+    TEST_ASSERT_TRUE(CoreLogLevel::WARN < CoreLogLevel::INFO);
+    TEST_ASSERT_TRUE(CoreLogLevel::INFO < CoreLogLevel::CONFIG);
+    TEST_ASSERT_TRUE(CoreLogLevel::CONFIG < CoreLogLevel::DEBUG);
+    TEST_ASSERT_TRUE(CoreLogLevel::DEBUG < CoreLogLevel::VERBOSE);
+}
+
+void test_log_level_values() {
+    // Explicit value check - ensures enum values don't accidentally change
+    TEST_ASSERT_EQUAL(0, static_cast<int>(CoreLogLevel::NONE));
+    TEST_ASSERT_EQUAL(1, static_cast<int>(CoreLogLevel::ERROR));
+    TEST_ASSERT_EQUAL(2, static_cast<int>(CoreLogLevel::WARN));
+    TEST_ASSERT_EQUAL(3, static_cast<int>(CoreLogLevel::INFO));
+    TEST_ASSERT_EQUAL(4, static_cast<int>(CoreLogLevel::CONFIG));
+    TEST_ASSERT_EQUAL(5, static_cast<int>(CoreLogLevel::DEBUG));
+    TEST_ASSERT_EQUAL(6, static_cast<int>(CoreLogLevel::VERBOSE));
+}
+
+// ============================================================================
+// setLogLevel / getLogLevel
+// ============================================================================
+
+void test_set_get_log_level() {
+    Logger::setLogLevel(CoreLogLevel::DEBUG);
+    TEST_ASSERT_EQUAL(CoreLogLevel::DEBUG, Logger::getLogLevel());
+    
+    Logger::setLogLevel(CoreLogLevel::ERROR);
+    TEST_ASSERT_EQUAL(CoreLogLevel::ERROR, Logger::getLogLevel());
+    
+    Logger::setLogLevel(CoreLogLevel::NONE);
+    TEST_ASSERT_EQUAL(CoreLogLevel::NONE, Logger::getLogLevel());
+}
+
+void test_default_log_level() {
+    // After init or reset, default should be INFO
+    Logger::setLogLevel(CoreLogLevel::INFO);
+    TEST_ASSERT_EQUAL(CoreLogLevel::INFO, Logger::getLogLevel());
+}
+
+// ============================================================================
+// Log Function Calls - Verify No Crashes
+// These tests verify the log functions handle various inputs without crashing
+// ============================================================================
+
+void test_log_functions_no_args() {
+    // Simple string with no format specifiers
+    Logger::setLogLevel(CoreLogLevel::VERBOSE);
+    
+    // Should not crash
+    Logger::error("simple error message");
+    Logger::warn("simple warning");
+    Logger::info("simple info");
+    Logger::config("simple config");
+    Logger::debug("simple debug");
+    Logger::verbose("simple verbose");
+    
+    TEST_PASS();
+}
+
+void test_log_functions_with_args() {
+    Logger::setLogLevel(CoreLogLevel::VERBOSE);
+    
+    // Various format specifiers
+    Logger::info("int: %d", 42);
+    Logger::info("string: %s", "test");
+    Logger::info("float: %.2f", 3.14f);
+    Logger::info("multiple: %d, %s, %.1f", 1, "two", 3.0f);
+    
+    TEST_PASS();
+}
+
+void test_log_macros_compile() {
+    Logger::setLogLevel(CoreLogLevel::VERBOSE);
+    
+    // Verify macros expand correctly
+    LOG_E("error via macro");
+    LOG_W("warn via macro");
+    LOG_I("info via macro");
+    LOG_C("config via macro");
+    LOG_D("debug via macro");
+    LOG_V("verbose via macro");
+    
+    // With arguments
+    LOG_I("value: %d", 123);
+    
+    TEST_PASS();
+}
+
+// ============================================================================
+// Level Filtering - Verify Messages Are Suppressed at Lower Levels
+// ============================================================================
+
+void test_none_level_suppresses_all() {
+    Logger::setLogLevel(CoreLogLevel::NONE);
+    
+    // At NONE level, even ERROR should be suppressed
+    // (We can't easily verify output, but we verify no crash)
+    Logger::error("should not appear");
+    Logger::warn("should not appear");
+    Logger::info("should not appear");
+    
+    TEST_PASS();
+}
+
+void test_error_level_filtering() {
+    Logger::setLogLevel(CoreLogLevel::ERROR);
+    
+    // Only ERROR should pass through at ERROR level
+    // WARN, INFO, etc. should be filtered
+    // Verify level check logic
+    TEST_ASSERT_TRUE(CoreLogLevel::ERROR >= CoreLogLevel::ERROR);   // passes
+    TEST_ASSERT_FALSE(CoreLogLevel::ERROR >= CoreLogLevel::WARN);   // filtered
+    TEST_ASSERT_FALSE(CoreLogLevel::ERROR >= CoreLogLevel::INFO);   // filtered
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+void test_empty_format_string() {
+    Logger::setLogLevel(CoreLogLevel::INFO);
+    
+    // Empty string should not crash
+    Logger::info("");
+    
+    TEST_PASS();
+}
+
+void test_null_string_in_format() {
+    Logger::setLogLevel(CoreLogLevel::INFO);
+    
+    // Note: Passing NULL to %s is undefined behavior in C, but some
+    // implementations handle it gracefully. This test documents the risk.
+    // In production code, always check for NULL before logging strings.
+    
+    // We don't test this as it's UB, but document it exists
+    TEST_PASS();
+}
+
+// ============================================================================
+// Test Runner
+// ============================================================================
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    
+    // Level ordering (critical for filtering)
+    RUN_TEST(test_log_levels_ordered);
+    RUN_TEST(test_log_level_values);
+    
+    // Level management
+    RUN_TEST(test_set_get_log_level);
+    RUN_TEST(test_default_log_level);
+    
+    // Function calls (no crash)
+    RUN_TEST(test_log_functions_no_args);
+    RUN_TEST(test_log_functions_with_args);
+    RUN_TEST(test_log_macros_compile);
+    
+    // Filtering
+    RUN_TEST(test_none_level_suppresses_all);
+    RUN_TEST(test_error_level_filtering);
+    
+    // Edge cases
+    RUN_TEST(test_empty_format_string);
+    RUN_TEST(test_null_string_in_format);
+    
+    return UNITY_END();
+}


### PR DESCRIPTION
- Brightness scaling: adapted so that we get full range, enabling much lower brightness levels while showing changes more gradually (like a volume knob, `log(x)` changes). 
- Reduce frequent writes to eeprom (thus extending lifetime), like a rate-limiter for updates
- switch from EEPROM to the Preferences library, still compatible API `read(), write(), readString(), writeString()` but more compatible with ESP32 and does wear-leveling and uses named values instead of raw addresses
- Added test suites for siebenuhr_core to cover logic, settings, color, config, etc and runnable in native (non-hw) environment (using mocks, avoiding testing fastled or sensors at this level)
- Added platformio.ini to siebenuhr_core (for tests)
- Updated FastLED to latest version (3.10.3)
- Documented build flags, added options to enable/disable FastLed dithering. It's disabled by default to ensure esphome at super low-level brightness doesn't flicker. Native firmware runs at 280fps, esphome shows 190fps.
- Fixed mapping of the LEDs, updated docs. Heartbeat flashes at 2Hz, button leds light when button is pressed.
